### PR TITLE
Added dragging toggle

### DIFF
--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -363,6 +363,8 @@
       </div>
       <gf-form-switch class="gf-form" label="Dragging" label-class="width-10" checked="ctrl.panel.dragging" on-change="ctrl.toggleDragging()"></gf-form-switch>
       </div>
+      <gf-form-switch class="gf-form" label="Double Click Zoom" label-class="width-10" checked="ctrl.panel.doubleClickZoom" on-change="ctrl.toggleDoubleClickZoom()"></gf-form-switch>
+      </div>
       <!-- Legend -->
       <div class="gf-form-subgroup">
       <gf-form-switch class="gf-form" label="Show Legend" label-class="width-10" checked="ctrl.panel.showLegend" on-change="ctrl.toggleLegend()"></gf-form-switch>

--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -361,7 +361,8 @@
       <gf-form-switch class="gf-form" label="Show Zoom Control" label-class="width-10" checked="ctrl.panel.showZoomControl" on-change="ctrl.restart()"></gf-form-switch>
       <gf-form-switch class="gf-form" label="Mouse Wheel Zoom" label-class="width-10" checked="ctrl.panel.mouseWheelZoom" on-change="ctrl.toggleMouseWheelZoom()"></gf-form-switch>
       </div>
-
+      <gf-form-switch class="gf-form" label="Dragging" label-class="width-10" checked="ctrl.panel.dragging" on-change="ctrl.toggleDragging()"></gf-form-switch>
+      </div>
       <!-- Legend -->
       <div class="gf-form-subgroup">
       <gf-form-switch class="gf-form" label="Show Legend" label-class="width-10" checked="ctrl.panel.showLegend" on-change="ctrl.toggleLegend()"></gf-form-switch>

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -48,6 +48,7 @@ export default class WorldMap {
     });
     this.setMouseWheelZoom();
     this.setDragging();
+    this.setDoubleClickZoom();
 
     const selectedTileServer = tileServers[this.ctrl.tileServer];
     (window as any).L.tileLayer(selectedTileServer.url, {

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -47,6 +47,7 @@ export default class WorldMap {
       attributionControl: this.ctrl.settings.showAttribution,
     });
     this.setMouseWheelZoom();
+    this.setDragging();
 
     const selectedTileServer = tileServers[this.ctrl.tileServer];
     (window as any).L.tileLayer(selectedTileServer.url, {
@@ -442,6 +443,14 @@ export default class WorldMap {
       this.map.scrollWheelZoom.disable();
     } else {
       this.map.scrollWheelZoom.enable();
+    }
+  }
+
+  setDragging() {
+    if (!this.ctrl.settings.dragging) {
+      this.map.dragging.disable();
+    } else {
+      this.map.dragging.enable();
     }
   }
 

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -454,6 +454,14 @@ export default class WorldMap {
     }
   }
 
+  setDoubleClickZoom() {
+    if (!this.ctrl.settings.doubleClickZoom) {
+      this.map.doubleClickZoom.disable();
+    } else {
+      this.map.doubleClickZoom.enable();
+    }
+  }
+
   addCircles(circles) {
     // Todo: Optionally add fixed custom attributions to the circle layer.
     const attribution = undefined;

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -41,6 +41,7 @@ const panelDefaults = {
   customAttributionText: null,
   mouseWheelZoom: false,
   dragging: true,
+  doubleClickZoom: true,
   esGeoPoint: null,
   // Todo: Investigate: Is "Count" a reasonable default here
   //  or does it confuse the operator?
@@ -507,6 +508,11 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
 
   toggleDragging() {
     this.map.setDragging();
+    this.render();
+  }
+
+  toggleDoubleClickZoom() {
+    this.map.setDoubleClickZoom();
     this.render();
   }
 

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -40,6 +40,7 @@ const panelDefaults = {
   customAttribution: false,
   customAttributionText: null,
   mouseWheelZoom: false,
+  dragging: true,
   esGeoPoint: null,
   // Todo: Investigate: Is "Count" a reasonable default here
   //  or does it confuse the operator?
@@ -501,6 +502,11 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
 
   toggleMouseWheelZoom() {
     this.map.setMouseWheelZoom();
+    this.render();
+  }
+
+  toggleDragging() {
+    this.map.setDragging();
     this.render();
   }
 


### PR DESCRIPTION
This adds a toggle to disable panning/dragging on the map. 

This is particularly useful for mobile use.