### PR TITLE
Add categorical colors

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -186,3 +186,14 @@ export const MapCenters = [
     data: { mapCenterLatitude: 59.32549, mapCenterLongitude: 18.07109, initialZoom: 11 },
   },
 ];
+
+export const ColorModes = {
+  threshold: {
+    id: 'threshold',
+    label: 'threshold',
+  },
+  categories: {
+    id: 'categories',
+    label: 'categories',
+  },
+};

--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -283,7 +283,8 @@
 <script type="text/ng-template" id="help_location_fields">
   <li>
     <b>Label field (optional)</b>: Enter the name of the location name column. Used to label each circle on the
-    map. If it is empty then the geohash value is used as the label.</li>
+    map. If it is empty then the geohash value is used as the label and can also be used to colorize the circle
+    by mapping the value against configured categories.</li>
   <li ng-show="ctrl.panel.locationData == 'table+json' || ctrl.panel.locationData == 'table+jsonp'">
     <b>Label location key field (optional)</b>: Enter the name of the location key column. The value from this column
     will get used to lookup the location name by matching it against the value of the key attribute of the locations
@@ -420,12 +421,30 @@
     </div>
 
     <div class="gf-form-group" style="overflow-x: visible">
-      <h5>Map thresholds to colors</h5>
+      <h5>Map data to colors</h5>
+
       <div class="gf-form">
+        <label class="gf-form-label width-10">Color mode</label>
+        <div class="gf-form-select-wrapper max-width-10">
+          <select class="input-small gf-form-input"
+                  ng-model="ctrl.panel.colorMode"
+                  ng-options="option.id as option.label for (unused, option) in ctrl.getColorModeChoices()"
+                  ng-change="ctrl.changeColorMode()">
+          </select>
+        </div>
+      </div>
+
+      <div class="gf-form" ng-show="ctrl.panel.colorMode === 'categories'">
+        <label class="gf-form-label width-10">Categories</label>
+        <input type="text" class="input-small gf-form-input width-18" ng-model="ctrl.panel.categories" ng-change="ctrl.changeColorMode()"
+               placeholder="a,b" ng-model-onblur />
+      </div>
+      <div class="gf-form" ng-show="ctrl.panel.colorMode === 'threshold' || !ctrl.panel.colorMode">
         <label class="gf-form-label width-10">Threshold values</label>
-        <input type="text" class="input-small gf-form-input width-18" ng-model="ctrl.panel.thresholds" ng-change="ctrl.changeThresholds()"
+        <input type="text" class="input-small gf-form-input width-18" ng-model="ctrl.panel.thresholds" ng-change="ctrl.changeColorMode()"
                placeholder="0,10" ng-model-onblur />
       </div>
+
       <div class="gf-form" style2="overflow-x: visible">
         <label class="gf-form-label width-10">Colors</label>
         <div class="width-24" style="display: inline-flex">

--- a/src/worldmap.test.ts
+++ b/src/worldmap.test.ts
@@ -162,7 +162,7 @@ describe('Worldmap', () => {
         .build();
       ctrl.panel.circleMinSize = '2';
       ctrl.panel.circleMaxSize = '10';
-      ctrl.panel.ColorMode = ColorModes.threshold.id;
+      ctrl.panel.colorMode = ColorModes.threshold.id;
       worldMap.drawCircles();
     });
 

--- a/src/worldmap.test.ts
+++ b/src/worldmap.test.ts
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import PluginSettings from './settings';
 import { TemplateSrv } from 'grafana/app/features/templating/template_srv';
 import DataFormatter from './data_formatter';
+import { ColorModes } from './model';
 
 describe('Worldmap', () => {
   let worldMap;
@@ -147,6 +148,56 @@ describe('Worldmap', () => {
       expect(worldMap.circles[0]._popup._content).toBe('Sweden: 1');
       expect(worldMap.circles[1]._popup._content).toBe('Ireland: 2');
       expect(worldMap.circles[2]._popup._content).toBe('United States: 3');
+    });
+  });
+
+  describe('when the data has three points and color mode is threshold', () => {
+    beforeEach(() => {
+      ctrl.data = new DataBuilder()
+        .withCountryAndValue('SE', 1)
+        .withCountryAndValue('IE', 2)
+        .withCountryAndValue('US', 3)
+        .withDataRange(1, 3, 2)
+        .withThresholdValues([2])
+        .build();
+      ctrl.panel.circleMinSize = '2';
+      ctrl.panel.circleMaxSize = '10';
+      ctrl.panel.ColorMode = ColorModes.threshold.id;
+      worldMap.drawCircles();
+    });
+
+    it('should set red color on values under threshold', () => {
+      expect(worldMap.circles[0].options.color).toBe('red');
+    });
+
+    it('should set blue color on values equal to or over threshold', () => {
+      expect(worldMap.circles[1].options.color).toBe('blue');
+      expect(worldMap.circles[2].options.color).toBe('blue');
+    });
+  });
+
+  describe('when the data has three points and color mode is categories', () => {
+    beforeEach(() => {
+      ctrl.data = new DataBuilder()
+        .withCountryAndValue('SE', 1)
+        .withCountryAndValue('IE', 2)
+        .withCountryAndValue('US', 3)
+        .withDataRange(1, 3, 2)
+        .withCategories(['Sweden'])
+        .build();
+      ctrl.panel.circleMinSize = '2';
+      ctrl.panel.circleMaxSize = '10';
+      ctrl.panel.colorMode = ColorModes.categories.id;
+      worldMap.drawCircles();
+    });
+
+    it('should set red color on locations not defined in categories', () => {
+      expect(worldMap.circles[1].options.color).toBe('red');
+      expect(worldMap.circles[2].options.color).toBe('red');
+    });
+
+    it('should set blue color on defined categories', () => {
+      expect(worldMap.circles[0].options.color).toBe('blue');
     });
   });
 
@@ -319,6 +370,42 @@ describe('Worldmap', () => {
           '<i style="background:red"></i> &lt; 2</div><div class="legend-item"><i style="background:blue"></i> 2–4</div>' +
           '<div class="legend-item"><i style="background:green"></i> 4–6</div>' +
           '<div class="legend-item"><i style="background:undefined"></i> 6+</div></div>'
+      );
+    });
+  });
+
+  describe('when three thresholds are set and color mode is threshold', () => {
+    beforeEach(() => {
+      ctrl.panel.colorMode = ColorModes.threshold.id;
+      ctrl.data = new DataBuilder().withThresholdValues([2, 4, 6]).build();
+      worldMap.createLegend();
+    });
+
+    it('should create a legend with four legend values', () => {
+      expect(worldMap.legend).toBeDefined();
+      expect(worldMap.legend._div.outerHTML).toBe(
+        '<div class="info legend leaflet-control"><div class="legend-item">' +
+          '<i style="background:red"></i> &lt; 2</div><div class="legend-item"><i style="background:blue"></i> 2–4</div>' +
+          '<div class="legend-item"><i style="background:green"></i> 4–6</div>' +
+          '<div class="legend-item"><i style="background:undefined"></i> 6+</div></div>'
+      );
+    });
+  });
+
+  describe('when three thresholds are set and color mode is categories', () => {
+    beforeEach(() => {
+      ctrl.panel.colorMode = ColorModes.categories.id;
+      ctrl.data = new DataBuilder().withCategories(['some cat', 'other cat', 'asdf']).build();
+      worldMap.createLegend();
+    });
+
+    it('should create a legend with four legend values', () => {
+      expect(worldMap.legend).toBeDefined();
+      expect(worldMap.legend._div.outerHTML).toBe(
+        '<div class="info legend leaflet-control"><div class="legend-item">' +
+          '<i style="background:red"></i> *</div><div class="legend-item"><i style="background:blue"></i> some cat</div>' +
+          '<div class="legend-item"><i style="background:green"></i> other cat</div>' +
+          '<div class="legend-item"><i style="background:undefined"></i> asdf</div></div>'
       );
     });
   });

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -412,7 +412,6 @@ export default class WorldMap {
   getColor(dataPoint) {
     switch (this.ctrl.settings.colorMode) {
       case ColorModes.categories.id:
-        console.log(dataPoint);
         return this.getCategoryColor(dataPoint.locationName);
       case ColorModes.threshold.id:
       default:

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import $ from 'jquery';
 import * as L from './libs/leaflet';
 import WorldmapCtrl from './worldmap_ctrl';
+import { ColorModes } from './model';
 
 const tileServers = {
   'CartoDB Positron': {
@@ -101,6 +102,35 @@ export default class WorldMap {
     return zoomLevel;
   }
 
+  private getLegendUpdateFunction() {
+    switch (this.ctrl.settings.colorMode) {
+      case ColorModes.categories.id:
+        return () => {
+          const legendHtml = this.ctrl.data.categories.reduce((html, cat, idx) => {
+            return html + '<div class="legend-item"><i style="background:' + this.ctrl.settings.colors[idx + 1] + '"></i> ' + cat + '</div>';
+          }, '<div class="legend-item"><i style="background:' + this.ctrl.settings.colors[0] + '"></i> *</div>');
+          this.legend._div.innerHTML = legendHtml;
+        };
+      case ColorModes.threshold.id:
+      default:
+        return () => {
+          const thresholds = this.ctrl.data.thresholds;
+          let legendHtml = '';
+          legendHtml +=
+            '<div class="legend-item"><i style="background:' + this.ctrl.settings.colors[0] + '"></i> ' + '&lt; ' + thresholds[0] + '</div>';
+          for (let index = 0; index < thresholds.length; index += 1) {
+            legendHtml +=
+              '<div class="legend-item"><i style="background:' +
+              this.ctrl.settings.colors[index + 1] +
+              '"></i> ' +
+              thresholds[index] +
+              (thresholds[index + 1] ? '&ndash;' + thresholds[index + 1] + '</div>' : '+');
+          }
+          this.legend._div.innerHTML = legendHtml;
+        };
+    }
+  }
+
   createLegend() {
     this.legend = (window as any).L.control({ position: 'bottomleft' });
     this.legend.onAdd = () => {
@@ -109,20 +139,7 @@ export default class WorldMap {
       return this.legend._div;
     };
 
-    this.legend.update = () => {
-      const thresholds = this.ctrl.data.thresholds;
-      let legendHtml = '';
-      legendHtml += '<div class="legend-item"><i style="background:' + this.ctrl.settings.colors[0] + '"></i> ' + '&lt; ' + thresholds[0] + '</div>';
-      for (let index = 0; index < thresholds.length; index += 1) {
-        legendHtml +=
-          '<div class="legend-item"><i style="background:' +
-          this.ctrl.settings.colors[index + 1] +
-          '"></i> ' +
-          thresholds[index] +
-          (thresholds[index + 1] ? '&ndash;' + thresholds[index + 1] + '</div>' : '+');
-      }
-      this.legend._div.innerHTML = legendHtml;
-    };
+    this.legend.update = this.getLegendUpdateFunction();
     this.legend.addTo(this.map);
 
     // Optionally display legend in different DOM element.
@@ -234,8 +251,8 @@ export default class WorldMap {
   createCircle(dataPoint) {
     const circle = (window as any).L.circleMarker([dataPoint.locationLatitude, dataPoint.locationLongitude], {
       radius: this.calcCircleSize(dataPoint.value || 0),
-      color: this.getColor(dataPoint.value),
-      fillColor: this.getColor(dataPoint.value),
+      color: this.getColor(dataPoint),
+      fillColor: this.getColor(dataPoint),
       fillOpacity: 0.5,
       location: dataPoint.key,
       stroke: Boolean(this.ctrl.settings.circleOptions.strokeEnabled),
@@ -257,8 +274,8 @@ export default class WorldMap {
     if (circle) {
       circle.setRadius(this.calcCircleSize(dataPoint.value || 0));
       circle.setStyle({
-        color: this.getColor(dataPoint.value),
-        fillColor: this.getColor(dataPoint.value),
+        color: this.getColor(dataPoint),
+        fillColor: this.getColor(dataPoint),
         fillOpacity: 0.5,
         location: dataPoint.key,
       });
@@ -374,13 +391,33 @@ export default class WorldMap {
     return label;
   }
 
-  getColor(value) {
+  private getCategoryColor(label) {
+    for (let index = 0; index !== this.ctrl.data.categories.length; index += 1) {
+      if (this.ctrl.data.categories[index] === label) {
+        return this.ctrl.settings.colors[index + 1];
+      }
+    }
+    return _.first(this.ctrl.settings.colors);
+  }
+
+  private getThresholdColor(value) {
     for (let index = this.ctrl.data.thresholds.length; index > 0; index -= 1) {
       if (value >= this.ctrl.data.thresholds[index - 1]) {
         return this.ctrl.settings.colors[index];
       }
     }
     return _.first(this.ctrl.settings.colors);
+  }
+
+  getColor(dataPoint) {
+    switch (this.ctrl.settings.colorMode) {
+      case ColorModes.categories.id:
+        console.log(dataPoint);
+        return this.getCategoryColor(dataPoint.locationName);
+      case ColorModes.threshold.id:
+      default:
+        return this.getThresholdColor(dataPoint.value);
+    }
   }
 
   resize() {

--- a/test/data_builder.ts
+++ b/test/data_builder.ts
@@ -4,6 +4,7 @@ export default class DataBuilder {
   constructor() {
     this.data = [];
     this.data.thresholds = [];
+    this.data.categories = [];
   }
 
   withCountryAndValue(countryCode, value) {
@@ -45,6 +46,12 @@ export default class DataBuilder {
 
   withThresholdValues(values) {
     this.data.thresholds = values;
+
+    return this;
+  }
+
+  withCategories(categories) {
+    this.data.categories = categories;
 
     return this;
   }


### PR DESCRIPTION
As requested in #20, we have decided to rebase our additions to the plugin on this fork, as it seems much more actively maintained and stable -- so first of all, thank you for providing this to the community.

This PR implements a simple approach to allow the circles to be colored by category (defined by their `Label`-field) rather than numeric thresholds. The purpose of this feature is to allow the worldmap-panel to be used in situations where different objects are being tracked over time, rather than aggregating data for fixed locations.

The code is modeled after the existing threshold approach, adding a dispatch layer where appropriate, which unfortunately also means it inherits its weaknesses (such as abusing `data` for the split thresholds and categories). This is certainly not ideal, but remodeling the whole settings-part in a backwards compatible way seemed to excessive for this small addition of functionality.