### PR TITLE
Upgrade e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,83 +122,7 @@ jobs:
         - ci/packages
         - ci/dist
         - ci/grafana-test-env
-  test_6_2_5:
-    docker:
-    - image: circleci/node:10-browsers
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Setup Grafana (local install)
-        command: |
-          wget https://dl.grafana.com/oss/release/grafana_6.2.5_amd64.deb
-          sudo apt-get install -y adduser libfontconfig1
-          sudo dpkg -i grafana_6.2.5_amd64.deb
-          sudo apt-get install locate
-          sudo updatedb
-          sudo locate grafana
-          sudo cat /etc/grafana/grafana.ini
-          sudo echo ------------------------
-          sudo cp ci/grafana-test-env/custom.ini /usr/share/grafana/conf/custom.ini
-          sudo cp ci/grafana-test-env/custom.ini /etc/grafana/grafana.ini
-          sudo service grafana-server start
-          sudo grafana-cli --version
-    - run:
-        name: Run e2e tests
-        command: |
-          npx grafana-toolkit plugin:ci-test
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/test_6_2_5
-    - store_test_results:
-        path: ci/jobs/test_6_2_5
-    - store_artifacts:
-        path: ci/jobs/test_6_2_5
-  test_6_3_6:
-    docker:
-    - image: circleci/node:10-browsers
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Setup Grafana (local install)
-        command: |
-          wget https://dl.grafana.com/oss/release/grafana_6.3.6_amd64.deb
-          sudo apt-get install -y adduser libfontconfig1
-          sudo dpkg -i grafana_6.3.6_amd64.deb
-          sudo apt-get install locate
-          sudo updatedb
-          sudo locate grafana
-          sudo cat /etc/grafana/grafana.ini
-          sudo echo ------------------------
-          sudo cp ci/grafana-test-env/custom.ini /usr/share/grafana/conf/custom.ini
-          sudo cp ci/grafana-test-env/custom.ini /etc/grafana/grafana.ini
-          sudo service grafana-server start
-          sudo grafana-cli --version
-    - run:
-        name: Run e2e tests
-        command: |
-          npx grafana-toolkit plugin:ci-test
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/test_6_3_6
-    - store_test_results:
-        path: ci/jobs/test_6_3_6
-    - store_artifacts:
-        path: ci/jobs/test_6_3_6
-  test_6_4_4:
+  test_6_7_4:
     docker:
       - image: circleci/node:10-browsers
     working_directory: ~/plugin
@@ -212,9 +136,9 @@ jobs:
       - run:
           name: Setup Grafana (local install)
           command: |
-            wget https://dl.grafana.com/oss/release/grafana_6.4.4_amd64.deb
+            wget https://dl.grafana.com/oss/release/grafana_6.7.4_amd64.deb
             sudo apt-get install -y adduser libfontconfig1
-            sudo dpkg -i grafana_6.4.4_amd64.deb
+            sudo dpkg -i grafana_6.7.4_amd64.deb
             sudo apt-get install locate
             sudo updatedb
             sudo locate grafana
@@ -231,12 +155,12 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ci/jobs/test_6_4_4
+            - ci/jobs/test_6_7_4
       - store_test_results:
-          path: ci/jobs/test_6_4_4
+          path: ci/jobs/test_6_7_4
       - store_artifacts:
-          path: ci/jobs/test_6_4_4
-  test_6_6_0:
+          path: ci/jobs/test_6_7_4
+  test_7_2_2:
     docker:
       - image: circleci/node:10-browsers
     working_directory: ~/plugin
@@ -250,9 +174,9 @@ jobs:
       - run:
           name: Setup Grafana (local install)
           command: |
-            wget https://dl.grafana.com/oss/release/grafana_6.6.0_amd64.deb
+            wget https://dl.grafana.com/oss/release/grafana_7.2.2_amd64.deb
             sudo apt-get install -y adduser libfontconfig1
-            sudo dpkg -i grafana_6.6.0_amd64.deb
+            sudo dpkg -i grafana_7.2.2_amd64.deb
             sudo apt-get install locate
             sudo updatedb
             sudo locate grafana
@@ -269,11 +193,11 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ci/jobs/test_6_6_0
+            - ci/jobs/test_7_2_2
       - store_test_results:
-          path: ci/jobs/test_6_6_0
+          path: ci/jobs/test_7_2_2
       - store_artifacts:
-          path: ci/jobs/test_6_6_0
+          path: ci/jobs/test_7_2_2
   report:
     docker:
     - image: circleci/node:10
@@ -300,17 +224,13 @@ workflows:
         requires:
         - build_plugin
         - build_docs
-    - test_6_2_5:
+    - test_6_7_4:
         requires:
-        - package
-    - test_6_3_6:
-        requires:
-        - package
-    - test_6_4_4:
+          - package
+    - test_7_2_2:
         requires:
           - package
     - report:
         requires:
-        - test_6_2_5
-        - test_6_3_6
-        - test_6_4_4
+        - test_6_7_4
+        - test_7_2_2


### PR DESCRIPTION
- Run CircleCI e2e tests against Grafana 6.7.4 and 7.2.2.
- Remove e2e tests against Grafana 6.2.5, 6.3.3 and 6.4.4.
