### PR TITLE
Update Basemaps URL and attributions

### DIFF
--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -5,18 +5,18 @@ import WorldmapCtrl from './worldmap_ctrl';
 import { ColorModes } from './model';
 
 const tileServers = {
-  'CartoDB Positron': {
-    url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+  'CARTO Positron': {
+    url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
     attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+      '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> ' +
+      '&copy; <a href="https://carto.com/about-carto/" target="_blank" rel="noopener">CARTO</a>',
     subdomains: 'abcd',
   },
-  'CartoDB Dark': {
-    url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+  'CARTO Dark': {
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',
     attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+      '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> ' +
+      '&copy; <a href="https://carto.com/about-carto/" target="_blank" rel="noopener">CARTO</a>',
     subdomains: 'abcd',
   },
 };

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -197,7 +197,7 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
     /*
      * Configure the Leaflet map widget.
      */
-    this.tileServer = contextSrv.user.lightTheme ? 'CartoDB Positron' : 'CartoDB Dark';
+    this.tileServer = contextSrv.user.lightTheme ? 'CARTO Positron' : 'CARTO Dark';
     this.setMapSaturationClass();
   }
 
@@ -205,7 +205,7 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
     /*
      * Configure the Leaflet map widget.
      */
-    if (this.tileServer === 'CartoDB Dark') {
+    if (this.tileServer === 'CARTO Dark') {
       this.saturationClass = 'map-darken';
     } else {
       this.saturationClass = '';

--- a/test/map_builder.ts
+++ b/test/map_builder.ts
@@ -17,7 +17,7 @@ export function createBasicMap() {
       showZoomControl: true,
       showAttribution: true,
     },
-    tileServer: 'CartoDB Positron',
+    tileServer: 'CARTO Positron',
   };
 
   // This mimics the `ctrl.panel` proxying established


### PR DESCRIPTION
# Summary
This PR updates basemaps URL to the new CDN URL and fixes the attributions to match current requirements. It also changes our old name from `CartoDB` to `CARTO` (although looks that basemaps names are internal and not exposed to the user, we could skip this if has any kind of side-effects on existing basemaps and just change URL and Attributions).

## Full context
We've recently changed our CDN and we have a plan mid-long term (depends on how quick we manage to stop all the traffic there) to deprecate our `.global.ssl.fastly.net` domains.