### PR TITLE
Overlay image can now be refreshed with the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ Optionally, you can show an image over the base map (but below the data points).
 
 Show/hide the overlay. 
 
+**Auto reload overlay**
+
+By default, the overlay image is fetched once, on page load, and never updated. If the overlay image is updated regularly (say, the overlay is generated on another application and then served on a fixed URL), it may be desirable to fetch the image when the dashboard is refreshed. This switch enables it. 
+
+If the overlay image is fixed (e. g., an orthomosaic of the area, taken with a drone), leave this option disabled, as it would cause an additional request on each dashboard reload.
+
 **Overlay URL**
 
 The URL where the image is available. Please notice that only URLs can be used (no local files!)

--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -554,6 +554,10 @@
     <gf-form-switch class="gf-form" label="Enable" label-class="width-10" checked="ctrl.panel.enableOverlay"
                     on-change="ctrl.refreshOverlay()">
     </gf-form-switch>
+    <gf-form-switch class="gf-form" ng-show="ctrl.panel.enableOverlay == true" 
+        label="Auto reload overlay" tooltip="Enable to update the image whenever the dashboard is refreshed" 
+        label-class="width-10" checked="ctrl.panel.enableReloadOverlay">
+    </gf-form-switch>
     <div class="gf-form" ng-show="ctrl.panel.enableOverlay == true">
         <label class="gf-form-label width-10">Overlay URL</label>
         <input type="url" class="input-small gf-form-input width-10" ng-model="ctrl.panel.overlayUrl"

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -63,6 +63,7 @@ const panelDefaults = {
   overlayOpacity: 0.5,
   overlayRangeLatitude: '0,10',
   overlayRangeLongitude: '0,20',
+  enableReloadOverlay: false,
   clickthroughUrl: '',
   clickthroughOptions: {
     windowName: null,
@@ -270,6 +271,10 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
       _.isEmpty(this.panel.snapshotLocationData)
     ) {
       this.loadLocationData(true);
+    }
+
+    if (this.panel.enableOverlay && this.panel.enableReloadOverlay) {
+      this.refreshOverlay();
     }
   }
 
@@ -550,8 +555,11 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
   }
 
   refreshOverlay() {
-    this.map.overlay.remove();
-    this.map.overlay = null;
+    if (this.map) {
+      this.map.overlay?.remove();
+      this.map.overlay = null;
+    }
+
     this.render();
   }
 


### PR DESCRIPTION
This PR closes https://github.com/panodata/grafana-map-panel/issues/97

As requested by @falconhome in https://github.com/panodata/grafana-map-panel/issues/97#issue-894036156, this PR adds a setting that refreshes the overlay image, if enabled, on each dashboard refresh. Currently, the overlay is fetched only once, on page load, and the only way to refresh it is to reload the page with F5 or to open a new tab.

This is not an issue if the image is fixed (for example, a more updated or detailed view of the area), but it can be a problem if the overlay is updated regularly (for example, a [heatmap computed from sensor data](https://medium.com/edyzaiot/heatmap-plots-spatial-interpolation-of-sensor-data-f60a7480f23f) that is updated as new sensor data streams in). In this case, it is desirable to display the latest/most recent image.

The PR adds a toggle switch that forces a reload of the overlay whenever the Grafana dashboard is refreshed, either manually via the refresh button or automatically on an interval.