### PR TITLE
Fix duplicate imports

### DIFF
--- a/src/types/leaflet_plus.d.ts
+++ b/src/types/leaflet_plus.d.ts
@@ -1,4 +1,3 @@
-import 'leaflet';
 import { DivOverlay, DivOverlayOptions } from 'leaflet';
 
 declare module 'leaflet' {

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -4,7 +4,6 @@ import './libs/leaflet_plus';
 import * as L from 'leaflet';
 import WorldmapCtrl from './worldmap_ctrl';
 import { ColorModes } from './model';
-import { LatLngExpression } from 'leaflet';
 
 const tileServers = {
   'CARTO Positron': {

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -499,7 +499,7 @@ export default class WorldMap {
     // controls the map centering and zoom level.
     const mapDimensions = this.ctrl.settings.center;
 
-    let coordinates: LatLngExpression = [mapDimensions.mapCenterLatitude, mapDimensions.mapCenterLongitude];
+    let coordinates: L.LatLngExpression = [mapDimensions.mapCenterLatitude, mapDimensions.mapCenterLongitude];
     let zoomLevel = mapDimensions.mapZoomLevel;
 
     if (mapDimensions.mapFitData) {


### PR DESCRIPTION
This PR closes #101.

I don't use to work with TypeScript projects, so I would appreciate some feedback on the change made on the `leaflet_plus.d.ts` file. Is it OK to simply delete the `import 'leaflet';` line? The [documentation](https://www.typescriptlang.org/docs/handbook/modules.html#import-a-module-for-side-effects-only) states that lines such as `import "package"` are not recommended but may be used for the side effects only:
> Though not recommended practice, some modules set up some global state that can be used by other modules. These modules may not have any exports, or the consumer is not interested in any of their exports.

Deleting the `import 'leaflet';` line fixes the linter error, and it doesn't appear to cause any errors. The code compiles successfully and tests pass.