### PR TITLE
Grafana 8: Don't croak when unable to load/access KeybindingSrv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## development
+- Add compatibility with Grafana 8
 
 ## v0.15.0
 - Support multiple metrics in popup content for Elasticsearch. Thanks, @matschaffer!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,9 @@ The easiest way to invoke a development sandbox is by using Docker.
 ```shell
 # Run with Grafana 7
 docker run --publish=3000:3000 --volume=$PWD/dist:/var/lib/grafana/plugins/grafana-map-panel grafana/grafana:7.5.7
+
+# Run with Grafana 8
+docker run --publish=3000:3000 --volume=$PWD/dist:/var/lib/grafana/plugins/grafana-map-panel --env=GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-map-panel grafana/grafana:8.0.0
 ```
 
 Because the version of `node-sass` used as transitive dependency is apparently

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -62,11 +62,19 @@ export class WorldmapChrome {
      * - https://github.com/daq-tools/grafanimate/blob/0.5.5/grafanimate/grafana-studio.js
      *
      */
-    this.getKeybindingSrv().unbind('esc', 'keydown');
+    try {
+      this.getKeybindingSrv().unbind('esc', 'keydown');
+    } catch (err) {
+      console.error(`Accessing KeybindingSrv not implemented for Grafana 8 yet.\n${err}`);
+    }
   }
 
   restoreEscapeKeyBinding() {
-    this.getKeybindingSrv().setupGlobal();
+    try {
+      this.getKeybindingSrv().setupGlobal();
+    } catch (err) {
+      console.error(`Accessing KeybindingSrv not implemented for Grafana 8 yet.\n${err}`);
+    }
   }
 
   getKeybindingSrv() {

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -298,8 +298,10 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
         this.panel.snapshotLocationData = this.locations;
       }
 
+      console.info('Processing data');
       this.processData(dataList);
 
+      console.info('Updating color mode');
       this.updateColorMode();
 
       const autoCenterMap =
@@ -504,6 +506,8 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
 
   resetData() {
     this.data = [];
+    this.data.categories = [];
+    this.data.thresholds = [];
     //this.mapCenterMoved = true;
   }
 


### PR DESCRIPTION
Hi there,

this addresses #103.

Apparently, the _KeybindingSrv_ service component will have to be addressed differently on Grafana 8. By now, the first patch  86d5db3 will just ignore / skip anything related to that, so we only lack minor functionality about »disabling keyboard navigation completely«, aka. the `ignoreEscapeKey` feature.

While this is a start, there might be more issues we will be running into, so we will be happy to receive any further reports from the community. Would someone also be available to verify this by building that branch using `npx yarn dev` and linking the `dist` folder into the Grafana plugin folder in order to check if the plugin with those improvements will actually work on real data?

With kind regards,
Andreas.

/cc @jm66, @MarcoPignati
